### PR TITLE
Beanstalk compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:2.4.1
 RUN  mkdir -p /opt/magicbox
 COPY . /opt/magicbox
 
-RUN gem install bundler --no-ri --no-rdoc
+RUN gem install bundler --without development --no-ri --no-rdoc
 
 WORKDIR /opt/magicbox
 RUN bundle install

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . /opt/magicbox
 RUN gem install bundler --no-ri --no-rdoc
 
 WORKDIR /opt/magicbox
-RUN bundle install
+RUN bundle install --without development
 
 EXPOSE 8443
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ gem 'puppet-lint', '2.3.3'
 gem 'puppet-syntax', '2.4.1'
 gem 'puppetlabs_spec_helper', '2.4.0'
 gem 'rspec-puppet', '2.6.9'
-gem 'rubocop', '~> 0.51.0'
 gem 'semantic_puppet', '1.0.1'
 gem 'sinatra', '2.0.0'
+
+group :development do
+  gem 'rubocop', '~> 0.51.0'
+end

--- a/assets/js/magicbox.js
+++ b/assets/js/magicbox.js
@@ -89,7 +89,7 @@ function fakeFail(msg) {
   resultComplete(xhr);
 }
 
-function submitcode(endpoint, data)
+function submitcode(endpoint, data, host = '')
   {
     resultWorking();
 
@@ -99,8 +99,8 @@ function submitcode(endpoint, data)
 
     // Submit API request
     $.ajax({ 
-      type:'post',
-      url:'/api/1.0/' + endpoint,
+      type: 'post',
+      url: host + '/api/1.0/' + endpoint,
       data: data,
       dataType:'json',
       success: function(res) { resultSuccess(res) },


### PR DESCRIPTION
* Rubocop doesn't install well on Beanstalk because it needs a compiler.  Moving that out as a development gem
* Adding a host option to `submitcode()` when coming from external sources.