### PR TITLE
Updating for $osfamily value

### DIFF
--- a/pages/facts/working_with_facts.erb
+++ b/pages/facts/working_with_facts.erb
@@ -2,7 +2,7 @@
 function test() {
   data = '{ \
     "code": "' + escape($('#magic-box').val()) + '", \
-    "check": "File%5C%5B%5C/etc%5C/motd%5C%5D.*d41d8cd98f00b204e9800998ecf8427e", \
+    "check": "File%5C%5B%5C/etc%5C/motd%5C%5D.*6417dfa291dda7c2024f869f0dcc625e", \
     "error": "Error: The file at /etc/motd was not correctly updated." \
   }';
   submitcode('apply', data)


### PR DESCRIPTION
Version on SLICE was expecting RedHat as the `$osfamily`. Version in AWS runs on Debian by default. Updated to look for Debian.