### PR TITLE
Using description field which has more human readable output

### DIFF
--- a/lib/magicbox/checks/relationship.rb
+++ b/lib/magicbox/checks/relationship.rb
@@ -27,13 +27,13 @@ module Magicbox::Checks
       else
         json    = JSON.parse(cmd_out)
         message = if exitstatus.zero?
-                    json.dig('examples', 0, 'status')
+                    [json.dig('examples', 0, 'status')]
                   else
-                    json.dig('examples', 0, 'exception', 'message')
+                    json['examples'].map { |x| x['description'] if x.key?('exception') }.compact
                   end
         {
           'exitcode' => exitstatus,
-          'message'  => [message],
+          'message'  => message,
         }
       end
     end


### PR DESCRIPTION
Not sure why, but the `exception` field I was using has the word "with" in there, but the `description` field does not.  The `description` field is always present, so I'm grabbing that only if the `exception` field exists, which is only if there is an error.

Also, if you are checking for more than 1 relationship, it was only displaying the first error even if there were multiple.