### PR TITLE
Making some small system changes the mimic internal systems

### DIFF
--- a/.ebextensions/magicbox.yaml
+++ b/.ebextensions/magicbox.yaml
@@ -1,0 +1,8 @@
+---
+commands:
+  create_webapp_homedir:
+    command:
+      - puppet resource file /home/webapp ensure=directory owner=webapp group=webapp
+  motd_link:
+    command:
+      - puppet resource file /etc/motd ensure=file


### PR DESCRIPTION
Using `.ebextensions` to create webapp home directory and make `/etc/motd` a file instead of a link for Beanstalk ruby apps.