### PR TITLE
Simplifying return message

### DIFF
--- a/pages/syntax/hello_world.erb
+++ b/pages/syntax/hello_world.erb
@@ -21,4 +21,7 @@ function test() {
   function munge_success(input) {
     return ['Hello world'];
   }
+  function munge_error(input) {
+    return ['ERROR: The content was not updated to \'Hello world\'.']
+  }
 </script>

--- a/pages/syntax/hello_world.erb
+++ b/pages/syntax/hello_world.erb
@@ -18,4 +18,7 @@ function test() {
 
 <script>
   formFooter();
+  function munge_success(input) {
+    return ['Hello world'];
+  }
 </script>


### PR DESCRIPTION
If the correct output is achieved, it is replaced with 'Hello world'.  Similarly, simplify error message.  The real success/error message available in browser's developer console.