### PR TITLE
operations attribute is deprecated

### DIFF
--- a/assets/js/tfe.js
+++ b/assets/js/tfe.js
@@ -109,6 +109,7 @@ function fetch_variables() {
       });
       ws_attributes = $.grep(workspaces_cache, function(ws) { return ws['id'] == $('#workspaces option:selected').attr('workspace_id') })[0]['attributes'];
       delete ws_attributes.name;
+      delete ws_attributes.operations;
       console.log(ws_attributes);
       $(document).ready(function() {
         $('#target_tfe_org').val($('#source_tfe_org').val());


### PR DESCRIPTION
422 error issue
```
"'operations' attribute is deprecated, and cannot be used in conjunction with 'execution'. Use the latter only."
```

Removing `operations` from the attribute hash.