### PR TITLE
Add ENV in Dockerfile to avoid Bundler 2 error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /opt/magicbox
 RUN bundle install --without development
 
 EXPOSE $port
+ENV BUNDLER_VERSION=2.1.4
 
 HEALTHCHECK --interval=1m --timeout=3s \
   CMD curl -sk -I -f ${protocol}://localhost:${port}/?healthcheck=1 || exit 1

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@
 
 Magic Box API and sample web UI.
 
+Docker Usage
+```shell
+docker run --rm -d -p 8443:8443 magicbox
+```
 ## Requirements
 
 * sinatra gem (>= 2.0.0)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Magic Box API and sample web UI.
 
 Docker Usage
 ```shell
-docker run --rm -d -p 8443:8443 magicbox
+docker run --rm -d -p 8443:8443 samgabrail/magicbox:latest
 ```
 ## Requirements
 


### PR DESCRIPTION
Add the following line in Dockerfile to avoid the error 
```
You must use Bundler 2 or greater with this lockfile.
```

`ENV BUNDLER_VERSION=2.1.4`