### PR TITLE
Updated tfecall to paginate for orgs with over 20 workspaces

### DIFF
--- a/lib/magicbox/checks/tfecall.rb
+++ b/lib/magicbox/checks/tfecall.rb
@@ -51,16 +51,16 @@ module Magicbox::Checks
         )
 
         # Get the link data for pagination
-        link_data = JSON.parse(raw)["links"]
+        link_data = JSON.parse(raw)['links']
         ret = @return_key.empty? ? JSON.parse(raw) : JSON.parse(raw)[@return_key]
-        while link_data["self"] != link_data["last"]
+        while link_data['self'] != link_data['last']
           next_page = http_call(
             @method,
-            link_data["next"],
+            link_data['next'],
             @keys,
             @e_codes
           )
-          link_data = JSON.parse(next_page)["links"]
+          link_data = JSON.parse(next_page)['links']
           ret.concat(@return_key.empty? ? JSON.parse(next_page) : JSON.parse(next_page)[@return_key])
         end
       rescue RuntimeError => e

--- a/lib/magicbox/checks/tfecall.rb
+++ b/lib/magicbox/checks/tfecall.rb
@@ -50,8 +50,19 @@ module Magicbox::Checks
           @e_codes
         )
 
-        # Return the requested key
+        # Get the link data for pagination
+        link_data = JSON.parse(raw)["links"]
         ret = @return_key.empty? ? JSON.parse(raw) : JSON.parse(raw)[@return_key]
+        while link_data["self"] != link_data["last"]
+          next_page = http_call(
+            @method,
+            link_data["next"],
+            @keys,
+            @e_codes
+          )
+          link_data = JSON.parse(next_page)["links"]
+          ret.concat(@return_key.empty? ? JSON.parse(next_page) : JSON.parse(next_page)[@return_key])
+        end
       rescue RuntimeError => e
         {
           'exitcode' => 2,


### PR DESCRIPTION
Since the page size is only 20, the API call to get Organizations only gets the first 20. This quick PR fixes this (for me at least)! 